### PR TITLE
Remove O_DIRECT since we don't have aligned data

### DIFF
--- a/lib/persistentNodeCache.js
+++ b/lib/persistentNodeCache.js
@@ -128,6 +128,9 @@ class PersistentNodeCache extends node_cache_1.default {
         }
         const appendData = fs_1.default.readFileSync(this.appendFilePath, 'utf-8');
         appendData.split(/\r?\n/).forEach((line) => {
+            if (line.length == 0) {
+                return;
+            }
             let data = this.serializer.deserialize(line);
             switch (data['cmd']) {
                 case 'set':
@@ -185,7 +188,7 @@ class PersistentNodeCache extends node_cache_1.default {
     }
     appendToFile(fileName, data) {
         this.changesSinceLastBackup = true;
-        const flags = fs_1.default.constants.O_WRONLY | fs_1.default.constants.O_DIRECT | fs_1.default.constants.O_APPEND;
+        const flags = fs_1.default.constants.O_WRONLY | fs_1.default.constants.O_APPEND;
         const mode = 0o666;
         if (this.appendFileDescriptor) {
             fs_1.default.write(this.appendFileDescriptor, data, 0, data.length, null, (writeErr, written, buffer) => {

--- a/lib/waitFor.d.ts
+++ b/lib/waitFor.d.ts
@@ -1,5 +1,5 @@
-export declare const waitFor: <Event_1 extends string>(event: Event_1, emitter: EventEmitter<Event_1>, callback?: Callback) => Promise<void>;
-export declare const removeListener: <Event_1 extends string>(emitter: EventEmitterOff<Event_1> | EventEmitterRemoveListener<Event_1>, event: "error" | Event_1, listener: EventListener) => void;
+export declare const waitFor: <Event extends string>(event: Event, emitter: EventEmitter<Event>, callback?: Callback) => Promise<void>;
+export declare const removeListener: <Event extends string>(emitter: EventEmitterOff<Event> | EventEmitterRemoveListener<Event>, event: Event | "error", listener: EventListener) => void;
 interface Callback {
     (error: any): void;
 }

--- a/src/persistentNodeCache.ts
+++ b/src/persistentNodeCache.ts
@@ -219,7 +219,7 @@ export default class PersistentNodeCache extends NodeCache {
 
     private appendToFile(fileName: string, data: Buffer): void {
         this.changesSinceLastBackup = true;
-        const flags = fs.constants.O_WRONLY | fs.constants.O_DIRECT | fs.constants.O_APPEND;
+        const flags = fs.constants.O_WRONLY | fs.constants.O_APPEND;
         const mode = 0o666;
 
         if(this.appendFileDescriptor) {

--- a/src/persistentNodeCache.ts
+++ b/src/persistentNodeCache.ts
@@ -223,7 +223,7 @@ export default class PersistentNodeCache extends NodeCache {
         const mode = 0o666;
 
         if(this.appendFileDescriptor) {
-            fs.write(this.appendFileDescriptor, data, 0, data.length, null, (writeErr, written, buffer) => {
+            fs.write(this.appendFileDescriptor, data as Uint8Array, 0, data.length, null, (writeErr, written, buffer) => {
                 if (writeErr) {
                     console.error('Error writing to file:', writeErr);
                 }
@@ -236,7 +236,7 @@ export default class PersistentNodeCache extends NodeCache {
                 return;
             }
             this.appendFileDescriptor = fd;
-            fs.write(fd, data, 0, data.length, null, (writeErr, written, buffer) => {
+            fs.write(fd, data as Uint8Array, 0, data.length, null, (writeErr, written, buffer) => {
                 if (writeErr) {
                     console.error('Error writing to file:', writeErr);
                 }


### PR DESCRIPTION
fs.constants.O_DIRECT requires the data to be at the same alignment at the filesystem which is complex to achieve. None of our data is aligned, so remove this flag.
Fixes #4 